### PR TITLE
fix: await instantiate since it performs async actions.

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -64,7 +64,7 @@ export default class Deploy extends Command {
       ? signer.key.accAddress
       : flags["admin-address"];
 
-    instantiate({
+    await instantiate({
       conf,
       signer,
       admin,


### PR DESCRIPTION
I've ran into an issue a few times where my refs get copied to the frontend repo with only the code ID after a successful deploy. Turns out we need to await the init command, when running against bombay or mainnet it can run a little slower. 