### PR TITLE
fix: pause between deploy/instantiate contract

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -59,6 +59,9 @@ export default class Deploy extends Command {
       refsPath: flags["refs-path"],
       lcd: lcd,
     });
+    
+    // pause for account sequence to update.
+    await new Promise(r => setTimeout(r, 1000));
 
     const admin = flags["set-signer-as-admin"]
       ? signer.key.accAddress


### PR DESCRIPTION
This PR attempts to solve the issue when deploying a contract via terrain.
See the following bug report: https://github.com/iboss-ptk/terrain/issues/23 Also (https://github.com/iboss-ptk/terrain/issues/22)

**What's going wrong?**
During each attempt at deployment I will receive an account mismatch sequence error. This sequence is always off by 1. And each time I do another deploy, both numbers get incremented by 1. I have attempted this about a dozen times.

```
CLIError: account sequence mismatch, expected 6, got 5: incorrect account sequence
```

**The solution**
Added a brief delay of 1s in between the `storeCode` and `instantiate` methods gives time for the next call to grab the correct sequence number - as it was just updated. 

In local testing, I have not run into any issues with deployment using this fix.