### PR TITLE
fix: Resolve account sequence errors and improve error handling. 

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -50,6 +50,9 @@ export default class Deploy extends Command {
       lcd,
     });
 
+    // Store sequence to manually increment after code is stored.
+    const sequence = await signer.sequence();
+
     const codeId = await storeCode({
       conf,
       noRebuild: flags["no-rebuild"],
@@ -64,10 +67,11 @@ export default class Deploy extends Command {
       ? signer.key.accAddress
       : flags["admin-address"];
 
-    instantiate({
+    await instantiate({
       conf,
       signer,
       admin,
+      sequence: 1 + sequence,
       contract: args.contract,
       codeId,
       network: flags.network,

--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -71,7 +71,7 @@ export const storeCode = async ({
   }
 
   let res;
-  for (let i = 0; i <= 100; i++) {
+  for (let i = 0; i <= 50; i++) {
     
     try {
       res = await lcd.tx.txInfo(result.txhash);
@@ -83,7 +83,7 @@ export const storeCode = async ({
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
   cli.action.stop()


### PR DESCRIPTION
This pull request includes a couple of fixes and improvements. 

1. Manually incrementing the account sequence to avoid the dreaded account sequence mismatch error. Closes #22 Closes #23
2. Explicit timeout handling. In the case that a transaction does not get included in a block Terrain will now report this to the user. This can happen for a number of reason, more details on this [here](https://docs.terra.money/docs/develop/sdks/terra-js/common-examples.html#avoid-status-500-timed-out-waiting-for-tx-to-be-included-in-a-block).

```
storing wasm bytecode on chain... done
 ›   Error: transaction not included in a block before timeout
```
3. Check the response from broadcastSync to verify there aren't any obvious issues with the transaction, for example: 

```
storing wasm bytecode on chain... !
 ›   Error: 0uluna is smaller than 1000000uluna: insufficient funds: insufficient funds
```

