### PR TITLE
fix: Enable automatic gas calculation

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -61,7 +61,6 @@ export const storeCode = async ({
         ? new MsgMigrateCode(signer.key.accAddress, codeId, wasmByteCode)
         : new MsgStoreCode(signer.key.accAddress, wasmByteCode),
     ],
-    fee: new Fee(store.fee.gasLimit, store.fee.amount),
   });
 
   const res = await lcd.tx.broadcast(storeCodeTx);
@@ -127,7 +126,6 @@ export const instantiate = async ({
         instantiation.instantiateMsg
       ),
     ],
-    fee: new Fee(instantiation.fee.gasLimit, instantiation.fee.amount),
   });
 
   const resInstant = await lcd.tx.broadcast(instantiateTx);
@@ -200,7 +198,6 @@ export const migrate = async ({
         instantiation.instantiateMsg
       ),
     ],
-    fee: new Fee(instantiation.fee.gasLimit, instantiation.fee.amount),
   });
 
   const resInstant = await lcd.tx.broadcast(instantiateTx);


### PR DESCRIPTION
When deploying larger contracts it's possible to get out of gas errors. instead of hardcoding these values we can let Terra.js estimate the required gas for us. 

This also means there's some outdated gas config values in `config.terrain.json`, should we get those updated now?