### PR TITLE
Remove broken cp command for when aarch64 file not present

### DIFF
--- a/src/lib/deployment.ts
+++ b/src/lib/deployment.ts
@@ -47,7 +47,6 @@ export const storeCode = async ({
   if (!noRebuild) {
     execSync("cargo wasm", { stdio: "inherit" });
     execSync("cargo run-script optimize", { stdio: "inherit" });
-    execSync(`cp artifacts/${contract.replace(/-/g, "_")}{-aarch64,}.wasm`);
   }
 
   const isNonArm64 = fs.existsSync(


### PR DESCRIPTION
Copying -aarch64 file is not necessary because the following lines read from either file correctly